### PR TITLE
Feat/157/run the application from console

### DIFF
--- a/AstroCal/__main__.py
+++ b/AstroCal/__main__.py
@@ -1,8 +1,40 @@
 import os
 import sys
-from sys import platform
+
+def show_help():
+	print("Available options:\n--TUI - Runs the application as a terminal interface.\n--GUI Runs the application as a graphical user interface with fewer features.")
+
+# Add AstroCal directory to Python path
+# Fixes our AstroCal.[...] imports
 script_dir = os.path.dirname( __file__ )
 path = os.path.join(script_dir, '..')
 sys.path.insert(0, path)
+
+n = len(sys.argv)
+use_terminal = False
+use_GUI = True
+for i in range (1, n):
+	opt = sys.argv[i]
+	if opt == "--TUI":
+		use_terminal = True
+		use_GUI = False
+	elif opt == "--GUI":
+		use_terminal = False
+		use_GUI = True
+	elif opt == "--help":
+		show_help()
+		exit()
+	else:
+		print("Unsupported option: " + opt)
+		show_help()
+		exit(1)
+
+
+# Remove any command line options as they confuse Kivy
+sys.argv = sys.argv[0:1]
+
 import core
-core.run()
+if use_terminal:
+	core.run_TUI()
+elif use_GUI:
+	core.run_GUI()

--- a/AstroCal/__main__.py
+++ b/AstroCal/__main__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+from sys import platform
+script_dir = os.path.dirname( __file__ )
+path = os.path.join(script_dir, '..')
+sys.path.insert(0, path)
+import core
+core.run()

--- a/AstroCal/core.py
+++ b/AstroCal/core.py
@@ -2,7 +2,6 @@ import AstroCal.view.console_output as console_output
 import AstroCal.view.Calendar_ui as calendar
 import AstroCal.view.home as home
 import sys
-import kivy
 
 
 def run():
@@ -11,10 +10,12 @@ def run():
     # app.run()
 
     # Runs UI
-    # calendar.CalendarApp().run()
+    calendar.CalendarApp().run()
 
     # Runs Console
-    console_output.main_menu()
+    # console_output.main_menu()
+
+
 
 
 if __name__ == "__main__":

--- a/AstroCal/core.py
+++ b/AstroCal/core.py
@@ -1,19 +1,18 @@
 import AstroCal.view.console_output as console_output
-import AstroCal.view.Calendar_ui as calendar
-import AstroCal.view.home as home
 import sys
 
 
-def run():
-    # Runs day page UI
-    # app = home
-    # app.run()
+def run_TUI():
+    # Runs Console
+    console_output.main_menu()
 
+def run_GUI():
     # Runs UI
+    import AstroCal.view.Calendar_ui as calendar
+    import AstroCal.view.home as home
     calendar.CalendarApp().run()
 
-    # Runs Console
-    # console_output.main_menu()
+
 
 
 
@@ -23,4 +22,4 @@ if __name__ == "__main__":
     MIN_PYTHON = (3, 8)
     if sys.version_info < MIN_PYTHON:
         sys.exit("Python %s.%s or later is required.\n" % MIN_PYTHON)
-    run()
+    run_TUI()

--- a/tests/test_All.py
+++ b/tests/test_All.py
@@ -1,3 +1,9 @@
+import os
+import sys
+from sys import platform
+script_dir = os.path.dirname( __file__ )
+path = os.path.join(script_dir, '..')
+sys.path.insert(0, path)
 import unittest
 
 import test_DaysTillNextFullMoon

--- a/tests/test_Eclipse.py
+++ b/tests/test_Eclipse.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import unittest
-
 from AstroCal.control.control import getWhenSolEclipseLoc, getWhenLunEclipseLoc
 
 


### PR DESCRIPTION
- Update Python's path when running all_Tests.py and ./AstroCal/
- Support running AstroCal through the command line with `python AstroCal`
  - Uses the __main__.py file in the AstroCal directory
- Select whether to run GUI or TUI from command line with options
  - `python AstroCal --TUI`
  - `python AstroCal --GUI`
- Get command line options with `python AstroCal --help`