### PR TITLE
 lun eclipse when loc fails

### DIFF
--- a/AstroCal/control/control.py
+++ b/AstroCal/control/control.py
@@ -150,19 +150,17 @@ def getDaysTillFullMoon(timezone, year=0, month=0, day=0):
 
 # Gets string of data relating to time of solar eclipse
 # Returns tuple (start of eclipse, peak of eclipse, end of eclipse, duration of eclipse)
-def getWhenSolEclipseLoc(year=None, month=None, day=None):
+def getWhenSolEclipse(year=None, month=None, day=None):
     if (year == None) & (month == None) & (day == None):
         now = datetime.now()
         year = now.year
         month = now.month
         day = now.day
     tjdut = swe.julday(year, month, day, 7, swe.GREG_CAL)
-    geopos = [-119.4960, 49.8880, 342.0]
-    retflags, tret, attr = swe.sol_eclipse_when_loc(
-        tjdut, geopos, swe.FLG_SWIEPH, False)
+    tret = swe.sol_eclipse_when_glob(tjdut)[1]
 
-    timeEclipseStart = swe.jdut1_to_utc(tret[1], swe.GREG_CAL)
-    timeEclipseEnd = swe.jdut1_to_utc(tret[4], swe.GREG_CAL)
+    timeEclipseStart = swe.jdut1_to_utc(tret[2], swe.GREG_CAL)
+    timeEclipseEnd = swe.jdut1_to_utc(tret[3], swe.GREG_CAL)
     timeEclipseMax = swe.jdut1_to_utc(tret[0], swe.GREG_CAL)
 
     # convert swisseph time to local time object
@@ -178,16 +176,14 @@ def getWhenSolEclipseLoc(year=None, month=None, day=None):
 
 # Gets string of data relating to time of Lunar eclipse
 # Returns tuple (start of eclipse, peak of eclipse, end of eclipse, duration of eclipse)
-def getWhenLunEclipseLoc(year=None, month=None, day=None):
+def getWhenLunEclipse(year=None, month=None, day=None):
     if (year == None) & (month == None) & (day == None):
         now = datetime.now()
         year = now.year
         month = now.month
         day = now.day
     tjdut = swe.julday(year, month, day, 7, swe.GREG_CAL)
-    geopos = [-119.4960, 49.8880, 342.0]
-    retflags, tret, attr = swe.lun_eclipse_when_loc(
-        tjdut, geopos, swe.FLG_SWIEPH, False)
+    tret = swe.lun_eclipse_when(tjdut)[1]
 
     timeEclipseStart = swe.jdut1_to_utc(tret[6], swe.GREG_CAL)
     timeEclipseEnd = swe.jdut1_to_utc(tret[7], swe.GREG_CAL)

--- a/AstroCal/view/console_output.py
+++ b/AstroCal/view/console_output.py
@@ -84,7 +84,7 @@ def sun_menu(option=None):
         print('Sun will Set : ' + format_24hour_time_output(sun_set_time) +
               " Days: " + str(sun_set_day))"""
     if option == 1:
-        sol_eclipse_start, sol_eclipse_max, sol_eclipse_end, sol_eclipse_duration = control.getWhenSolEclipseLoc(
+        sol_eclipse_start, sol_eclipse_max, sol_eclipse_end, sol_eclipse_duration = control.getWhenSolEclipse(
             DATE.year, DATE.month, DATE.day)
         print("Solar Eclipse:")
         print("\tStart:\t\t" + str(sol_eclipse_start))
@@ -162,7 +162,7 @@ def moon_menu(option=None):
         print('Moon will Set : ' + format_24hour_time_output(moon_set_time) +
               " Days: " + str(moon_set_day))"""
     if option == 1:
-        lun_eclipse_start, lun_eclipse_max, lun_eclipse_end, lun_eclipse_duration = control.getWhenLunEclipseLoc(
+        lun_eclipse_start, lun_eclipse_max, lun_eclipse_end, lun_eclipse_duration = control.getWhenLunEclipse(
             DATE.year, DATE.month, DATE.day)
         print("Lunar Eclipse:")
         print("\tStart:\t\t" + str(lun_eclipse_start))

--- a/tests/test_Eclipse.py
+++ b/tests/test_Eclipse.py
@@ -8,28 +8,28 @@ class TestEclipse(unittest.TestCase):
         sol_eclipse_date_time_start, sol_eclipse_date_time_max, sol_eclipse_date_time_end, sol_eclipse_date_time_duration = getWhenSolEclipse(
             2022, 9, 27)
         self.assertEqual(sol_eclipse_date_time_start.year,
-                         2023, "Year Test Fail")
+                         2022, "Year Test Fail")
         self.assertEqual(sol_eclipse_date_time_start.month,
                          10, "Month Test Fail")
         self.assertEqual(sol_eclipse_date_time_start.day,
-                         14, "Day Test Fail")
+                         25, "Day Test Fail")
         self.assertEqual(sol_eclipse_date_time_start.hour,
-                         8, "Hour Start Test Fail")
+                         1, "Hour Start Test Fail")
         self.assertEqual(sol_eclipse_date_time_start.minute,
-                         10, "Minute Start Test Fail")
+                         58, "Minute Start Test Fail")
 
         self.assertEqual(sol_eclipse_date_time_max.hour,
-                         9, "Hour Max Test Fail")
+                         4, "Hour Max Test Fail")
         self.assertEqual(sol_eclipse_date_time_max.minute,
-                         22, "Minute Max Test Fail")
+                         0, "Minute Max Test Fail")
 
         self.assertEqual(sol_eclipse_date_time_end.hour,
-                         10, "Hour End Test Fail")
+                         6, "Hour End Test Fail")
         self.assertEqual(sol_eclipse_date_time_end.minute,
-                         41, "Minute End Test Fail")
+                         2, "Minute End Test Fail")
 
         self.assertEqual(sol_eclipse_date_time_duration,
-                         timedelta(hours=2, minutes=31), "Duration Test Fail")
+                         timedelta(hours=4, minutes=4), "Duration Test Fail")
 
     def test_SolEcl_WhenUnsuccessful(self):
         sol_eclipse_date_time_start, sol_eclipse_date_time_max, sol_eclipse_date_time_end, sol_eclipse_date_time_duration = getWhenSolEclipse(
@@ -37,13 +37,13 @@ class TestEclipse(unittest.TestCase):
         self.assertNotEqual(sol_eclipse_date_time_start.year,
                             2023, "Year Test Fail")
         self.assertNotEqual(sol_eclipse_date_time_start.month,
-                            10, "Month Test Fail")
+                            4, "Month Test Fail")
         self.assertNotEqual(sol_eclipse_date_time_start.day,
-                            14, "Day Test Fail")
+                            20, "Day Test Fail")
         self.assertNotEqual(sol_eclipse_date_time_start.hour,
-                            8, "Hour Start Test Fail")
+                            1, "Hour Start Test Fail")
         self.assertNotEqual(sol_eclipse_date_time_start.minute,
-                            10, "Minute Start Test Fail")
+                            34, "Minute Start Test Fail")
 
         self.assertNotEqual(sol_eclipse_date_time_max.hour,
                             10, "Hour Max Test Fail")

--- a/tests/test_Eclipse.py
+++ b/tests/test_Eclipse.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timedelta
 import unittest
-from AstroCal.control.control import getWhenSolEclipseLoc, getWhenLunEclipseLoc
+from AstroCal.control.control import getWhenSolEclipse, getWhenLunEclipse
 
 
 class TestEclipse(unittest.TestCase):
     def test_SolEcl_WhenSuccessful(self):
-        sol_eclipse_date_time_start, sol_eclipse_date_time_max, sol_eclipse_date_time_end, sol_eclipse_date_time_duration = getWhenSolEclipseLoc(
+        sol_eclipse_date_time_start, sol_eclipse_date_time_max, sol_eclipse_date_time_end, sol_eclipse_date_time_duration = getWhenSolEclipse(
             2022, 9, 27)
         self.assertEqual(sol_eclipse_date_time_start.year,
                          2023, "Year Test Fail")
@@ -32,7 +32,7 @@ class TestEclipse(unittest.TestCase):
                          timedelta(hours=2, minutes=31), "Duration Test Fail")
 
     def test_SolEcl_WhenUnsuccessful(self):
-        sol_eclipse_date_time_start, sol_eclipse_date_time_max, sol_eclipse_date_time_end, sol_eclipse_date_time_duration = getWhenSolEclipseLoc(
+        sol_eclipse_date_time_start, sol_eclipse_date_time_max, sol_eclipse_date_time_end, sol_eclipse_date_time_duration = getWhenSolEclipse(
             2024, 9, 27)
         self.assertNotEqual(sol_eclipse_date_time_start.year,
                             2023, "Year Test Fail")
@@ -59,7 +59,7 @@ class TestEclipse(unittest.TestCase):
                             timedelta(hours=2, minutes=20), "Duration Test Fail")
 
     def test_LunEcl_WhenSuccessful(self):
-        lun_eclipse_date_time_start, lun_eclipse_date_time_max, lun_eclipse_date_time_end, lun_eclipse_date_time_duration = getWhenLunEclipseLoc(
+        lun_eclipse_date_time_start, lun_eclipse_date_time_max, lun_eclipse_date_time_end, lun_eclipse_date_time_duration = getWhenLunEclipse(
             2022, 9, 27)
         self.assertEqual(lun_eclipse_date_time_start.year,
                          2022, "Year Test Fail")
@@ -86,7 +86,7 @@ class TestEclipse(unittest.TestCase):
                          timedelta(hours=5, minutes=54), "Duration Test Fail")
 
     def test_LunEcl_WhenUnsuccessful(self):
-        lun_eclipse_date_time_start, lun_eclipse_date_time_max, lun_eclipse_date_time_end, lun_eclipse_date_time_duration = getWhenLunEclipseLoc(
+        lun_eclipse_date_time_start, lun_eclipse_date_time_max, lun_eclipse_date_time_end, lun_eclipse_date_time_duration = getWhenLunEclipse(
             2024, 9, 27)
         self.assertNotEqual(lun_eclipse_date_time_start.year,
                             2024, "Year Test Fail")


### PR DESCRIPTION
Due to us not using location at this current time. We have decided to switch sol eclipse and lunar eclipse to global methods.

- To note: Sol Eclipse and Lunar eclipse by location serve the chance that you may see the start but not see the end, you may see the end but not the start, you may not see it at all.